### PR TITLE
[WIP] Improve presentation of connection status

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -152,9 +152,11 @@ packages:
   web_socket_channel:
     dependency: "direct main"
     description:
-      name: web_socket_channel
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.12"
+      path: "."
+      ref: "feature/ready"
+      resolved-ref: "5584f5e5cc031aa2a08f32b0df50aade0d551fb9"
+      url: "git://github.com/artrmz/web_socket_channel.git"
+    source: git
+    version: "1.0.13"
 sdks:
   dart: ">=2.2.2 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  web_socket_channel: ^1.0.12
+  web_socket_channel:
+    git:
+      url: git://github.com/artrmz/web_socket_channel.git
+      ref: feature/ready
 
 dev_dependencies:
   flutter_test:

--- a/test/roslib_errors_test.dart
+++ b/test/roslib_errors_test.dart
@@ -1,11 +1,9 @@
 // Copyright (c) 2019 Conrad Heidebrecht.
 
-import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:roslib/roslib.dart';
 
 void main() {
-
   Ros ros;
 
   setUp(() {
@@ -21,5 +19,5 @@ void main() {
     expect(ros.statusStream, isNotNull);
     expect(ros.status, Status.ERRORED);
   });
-
+  
 }


### PR DESCRIPTION
New status 'CLOSING' used while the channel is being closed and set status CONNECTED once the connection has been established.

Also, this PR adds a possibility to set a timeout for the connection.

Closes #3 

**CAUTION:** I have marked is as _WIP_ since it requires https://github.com/dart-lang/web_socket_channel/pull/85 to be merged. Not sure if it ever happens (web_socket_channel kinda seems to be abandoned) so changed a dependency to point on my forked repo and branch with the fix.

Btw. Maybe it will be better to add a status `TIMEOUT` for some cases? Anyway, it's something to consider on another PR.